### PR TITLE
Fix "Edit on GitHub" link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/synthpops.*.rst
+docs/modules.rst
 
 # PyBuilder
 target/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -W
+SPHINXOPTS    = -W -A READTHEDOCS=True
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/docs/_templates/breadcrumbs.html
+++ b/docs/_templates/breadcrumbs.html
@@ -1,35 +1,9 @@
-{# Support for Sphinx 1.3+ page_source_suffix, but don't break old builds. #}
-
-{% if page_source_suffix %}
-{% set suffix = page_source_suffix %}
-{% else %}
-{% set suffix = source_suffix %}
-{% endif %}
-
-<div aria-label="breadcrumbs navigation" role="navigation">
-    <ul class="wy-breadcrumbs">
-        <li><a href="https://idmod.org/documentation">IDM docs</a> &raquo;</li>
-        <li><a href="{{ pathto(master_doc) }}">SynthPops</a> &raquo;</li>
-        {% for doc in parents %}
+{% extends '!breadcrumbs.html' %}
+{% block breadcrumbs %}
+    <li><a href="//idmod.org/documentation">IDM docs</a> &raquo;</li>
+    <li><a href="{{ pathto(master_doc) }}">SynthPops</a> &raquo;</li>
+    {% for doc in parents %}
         <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
-        {% endfor %}
-        <li>{{ title }}</li>
-        <li class="wy-breadcrumbs-aside">
-            {% if pagename != "search" %}
-            {% if display_github %}
-            <a github.comhref="https://{{ github_host|default("") }}/{{ github_user }}/{{ github_repo }}/blob/{{
-            github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"> Edit on GitHub</a>
-            {% elif display_bitbucket %}
-            <a class="fa fa-bitbucket"
-               href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ suffix }}">
-                Edit on Bitbucket</a>
-            {% elif show_source and source_url_prefix %}
-            <a href="{{ source_url_prefix }}{{ pagename }}{{ suffix }}">View page source</a>
-            {% elif show_source and has_source and sourcename %}
-            <a href="{{ pathto('_sources/' + sourcename, true)|e }}" rel="nofollow"> View page source</a>
-            {% endif %}
-            {% endif %}
-        </li>
-    </ul>
-    <hr/>
-</div>
+    {% endfor %}
+    <li>{{ title }}</li>
+{% endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -199,6 +199,7 @@ html_static_path = ['_static']
 
 html_context = {
     'rtd_url': 'https://docs.idmod.org/projects/synthpops/en/latest',
+    'theme_vcs_pageview_mode': 'edit',
     'css_files': [
         '_static/theme_overrides.css'
     ]

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -5,7 +5,7 @@ REM Command file for Sphinx documentation
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
-set SPHINXOPTS=-W
+set "SPHINXOPTS=-W -A READTHEDOCS=True"
 set BUILDDIR=_build
 set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
 set I18NSPHINXOPTS=%SPHINXOPTS% .


### PR DESCRIPTION
Fixed the "Edit on GitHub" link when building on RTD.
- Only override the specific breadcrumbs block instead of the entire side bar
- Changed the edit link to go directly to the web-based GitHub editing interface

Working example: https://docs.idmod.org/projects/synthpops/en/rtd_fix-github-edit-link/