### PR TITLE
added system_packages: true flag to RTD yaml file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,12 +21,12 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.7
-   install:
-      - requirements: docs/requirements.txt
-      - method: setuptools
-        path: .
-       
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt
+    - method: setuptools
+      path: .
+  system_packages: true
 
 # Optionally rank topics in search results, between -10 (lower) and 10 (higher).
 # 0 is normal rank, not no rank


### PR DESCRIPTION
Added a flag that will give the docs build access to numpy so you don't see the import error that's breaking the build. Also fixed the indentation under the Python installation section of the RTD yaml file. 