### PR TITLE
removed PDF doc build, deprecated system packages from Read the Docs …

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,7 +17,6 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF
 formats:
   - htmlzip
-  - pdf
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
@@ -26,7 +25,6 @@ python:
     - requirements: docs/requirements.txt
     - method: setuptools
       path: .
-  system_packages: true
 
 # Optionally rank topics in search results, between -10 (lower) and 10 (higher).
 # 0 is normal rank, not no rank


### PR DESCRIPTION
…config

Read the Docs is deprecating the "use system packages" build option and numpy, scipy, or other package dependencies must be declared in requirements.txt. I also removed the PDF build option, which may the what's currently causing build errors. The webhook also disappeared, so errors caused by that over the last month should be resolved. 